### PR TITLE
Always convert b to fortran array if b is not fortran contiguous

### DIFF
--- a/pypardiso/pardiso_wrapper.py
+++ b/pypardiso/pardiso_wrapper.py
@@ -232,8 +232,8 @@ class PyPardisoSolver:
                           SparseEfficiencyWarning)
             b = b.todense()
 
-        # pardiso expects fortran (column-major) order if b is a matrix
-        if b.ndim == 2:
+        # pardiso expects fortran (column-major) order for b
+        if not b.flags.f_contiguous:
             b = np.asfortranarray(b)
 
         if b.shape[0] != A.shape[0]:

--- a/tests/test_input_b.py
+++ b/tests/test_input_b.py
@@ -53,3 +53,12 @@ def test_input_b_wrong_shape():
     b = np.append(b, 1)
     with pytest.raises(ValueError):
         basic_solve(A, b)
+
+
+def test_input_b_slice():
+    A, b = create_test_A_b_rand(matrix=True)
+    b1 = b[:, 0]
+    b2 = b[:, 0].copy()
+    x1 = ps.solve(A, b1)
+    x2 = ps.solve(A, b2)
+    np.testing.assert_array_equal(x1, x2)

--- a/tests/test_scipy_aliases.py
+++ b/tests/test_scipy_aliases.py
@@ -1,4 +1,5 @@
 # coding: utf-8
+import pytest
 import numpy as np
 import scipy.sparse as sp
 from scipy.sparse.linalg import spsolve as scipyspsolve
@@ -28,6 +29,7 @@ def test_basic_spsolve_matrix():
     np.testing.assert_array_almost_equal(xpp, xscipy)
 
 
+@pytest.mark.filterwarnings("ignore:splu requires CSC matrix format")
 def test_basic_factorized():
     ps.remove_stored_factorization()
     ps.free_memory()
@@ -39,6 +41,7 @@ def test_basic_factorized():
     np.testing.assert_array_almost_equal(xpp, xscipy)
 
 
+@pytest.mark.filterwarnings("ignore:Changing the sparsity structure")
 def test_factorized_modified_A():
     ps.remove_stored_factorization()
     ps.free_memory()


### PR DESCRIPTION
This fixes a bug where pypardiso produces wrong results if b is a one-dimensional slice of c-contiguous array

Fixes #39 