### PR TITLE
Tests: Remove assert for unsorted indices

### DIFF
--- a/tests/test_input_A.py
+++ b/tests/test_input_A.py
@@ -11,7 +11,6 @@ ps = pypardiso_solver
 
 def test_input_A_unsorted_indices():
     A, b = create_test_A_b_small(sort_indices=False)
-    assert not A.has_sorted_indices
     ps._check_A(A)
     assert A.has_sorted_indices
     basic_solve(A, b)


### PR DESCRIPTION
SciPy 1.11 introduced some changes to how indices are handled. The test no longer produces a matrix A with unsorted indices. 1.11 release notes: https://docs.scipy.org/doc/scipy/release/1.11.0-notes.html